### PR TITLE
Fixed bug in Determinant()

### DIFF
--- a/BasicLinearAlgebra.h
+++ b/BasicLinearAlgebra.h
@@ -488,11 +488,11 @@ typename MemT::elem_t Determinant(const Matrix<dim,dim,MemT> &A)
     {
         Minor<MemT> del(A.delegate, i, 0);
         Matrix<dim-1,dim-1,Minor<MemT> > m(del);
-
-        if(!i)
-            det = Determinant(m);
+	    
+     	if (i%2)
+            det -= Determinant(m) * A(i,0);
         else
-            det += Determinant(m) * (i % 2? -A(i,0) : A(i,0));
+            det += Determinant(m) * A(i,0);
     }
 
     return det;


### PR DESCRIPTION
This PR fixes the bug in Determinant() function for arbitrary matrix dimension. The current implementation prevents the first term's minor matrix to be multiplied by its determinant. I explicitly changed the signs of each term(alternating) just to be safe. 

Here's the test code I was using:
https://gist.github.com/grassjelly/7ac9221febd197413f9ebb27883b01e1#file-determinant-test