### PR TITLE
Correct bug in inverse functions

### DIFF
--- a/impl/NotSoBasicLinearAlgebra.h
+++ b/impl/NotSoBasicLinearAlgebra.h
@@ -147,9 +147,10 @@ LUDecomposition<dim, MemT> LUDecompose(Matrix<dim, dim, MemT> &A)
 }
 
 template <int dim, class MemT1, class MemT2>
-Matrix<dim> LUSolve(const LUDecomposition<dim, MemT1> &decomp, const Matrix<dim, 1, MemT2> &b)
+ArrayMatrix<dim, 1, typename MemT2::elem_t> LUSolve(const LUDecomposition<dim, MemT1> &decomp,
+                                                    const Matrix<dim, 1, MemT2> &b)
 {
-    Matrix<dim, 1, MemT2> x, tmp;
+    ArrayMatrix<dim, 1, typename MemT2::elem_t> x, tmp;
 
     auto &idx = decomp.permutation.idx;
     auto &LU = decomp.lower.parent;
@@ -192,7 +193,7 @@ Matrix<dim> LUSolve(const LUDecomposition<dim, MemT1> &decomp, const Matrix<dim,
 template <int dim, class MemT>
 bool Invert(const Matrix<dim, dim, MemT> &A, Matrix<dim, dim, MemT> &out)
 {
-    Matrix<dim, dim> A_copy = A;
+    ArrayMatrix<dim, dim, typename MemT::elem_t> A_copy = A;
 
     auto decomp = LUDecompose(A_copy);
 
@@ -201,7 +202,7 @@ bool Invert(const Matrix<dim, dim, MemT> &A, Matrix<dim, dim, MemT> &out)
         return false;
     }
 
-    Matrix<dim> b = Zeros<dim>();
+    ArrayMatrix<dim, 1, typename MemT::elem_t> b = Zeros<dim>();
 
     for (int j = 0; j < dim; ++j)
     {
@@ -222,7 +223,7 @@ bool Invert(Matrix<dim, dim, MemT> &A)
 template <int dim, class MemT>
 Matrix<dim, dim, MemT> Inverse(const Matrix<dim, dim, MemT> &A)
 {
-    Matrix<dim, dim> out;
+    ArrayMatrix<dim, dim, typename MemT::elem_t> out;
     Invert(A, out);
     return out;
 }

--- a/test/test_linear_algebra.cpp
+++ b/test/test_linear_algebra.cpp
@@ -67,6 +67,18 @@ TEST(LinearAlgebra, Inversion)
     }
 }
 
+TEST(LinearAlgebra, DoublePrecisionInverse)
+{
+    ArrayMatrix<6, 6, double> A = {1. / 48.,  0,          0,         0, 0, 0, 0, 1. / 48.,  0,        0,       0, 0, 0,
+                                   -1. / 48., 1. / 48.,   0,         0, 0, 0, 0, 0,         1. / 24., 0,       0, 0, 0,
+                                   0,         -1. / 28.8, 1. / 28.8, 0, 0, 0, 0, -1. / 12., 1. / 24., 1. / 24.};
+
+    auto A_inv = Inverse(A * 1.8);
+
+    EXPECT_DOUBLE_EQ(A_inv(0, 0), 80.0 / 3.0);
+    EXPECT_DOUBLE_EQ(A_inv(5, 5), 40.0 / 3.0);
+}
+
 TEST(Arithmetic, Determinant)
 {
     Matrix<6, 6> B = {0.05508292, 0.82393504, 0.34938018, 0.63818054, 0.18291131, 0.1986636,  0.56799604, 0.81077491,


### PR DESCRIPTION
Which causes elements to be cast to `float` and lose precision when `elem_t` is `double`