### PR TITLE
Redesign Matrix class to use CRTP

### DIFF
--- a/BasicLinearAlgebra.h
+++ b/BasicLinearAlgebra.h
@@ -17,17 +17,9 @@ struct MatrixBase
     constexpr static int Cols = cols;
     using DType = d_type;
 
-    DType &operator()(int i, int j = 0)
-    {
-        assert(i < Rows && j < Cols);
-        return static_cast<DerivedType *>(this)->operator()(i, j);
-    }
+    DType &operator()(int i, int j = 0) { return static_cast<DerivedType *>(this)->operator()(i, j); }
 
-    DType operator()(int i, int j = 0) const
-    {
-        assert(i < Rows && j < Cols);
-        return static_cast<const DerivedType *>(this)->operator()(i, j);
-    }
+    DType operator()(int i, int j = 0) const { return static_cast<const DerivedType *>(this)->operator()(i, j); }
 
     MatrixBase() = default;
 
@@ -86,36 +78,36 @@ struct MatrixBase
     void Fill(const DType &val) { *this = val; }
 
     template <int SubRows, int SubCols>
-    MatrixRef<DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start)
+    RefMatrix<DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start)
     {
-        return MatrixRef<DerivedType, SubRows, SubCols>(static_cast<DerivedType &>(*this), row_start, col_start);
+        return RefMatrix<DerivedType, SubRows, SubCols>(static_cast<DerivedType &>(*this), row_start, col_start);
     }
 
     template <int SubRows, int SubCols>
-    MatrixRef<const DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start) const
+    RefMatrix<const DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start) const
     {
-        return MatrixRef<const DerivedType, SubRows, SubCols>(static_cast<const DerivedType &>(*this), row_start,
+        return RefMatrix<const DerivedType, SubRows, SubCols>(static_cast<const DerivedType &>(*this), row_start,
                                                               col_start);
     }
 
-    MatrixRef<DerivedType, 1, Cols> Row(int row_start)
+    RefMatrix<DerivedType, 1, Cols> Row(int row_start)
     {
-        return MatrixRef<DerivedType, 1, Cols>(static_cast<DerivedType &>(*this), row_start, 0);
+        return RefMatrix<DerivedType, 1, Cols>(static_cast<DerivedType &>(*this), row_start, 0);
     }
 
-    MatrixRef<const DerivedType, 1, Cols> Row(int row_start) const
+    RefMatrix<const DerivedType, 1, Cols> Row(int row_start) const
     {
-        return MatrixRef<const DerivedType, 1, Cols>(static_cast<const DerivedType &>(*this), row_start, 0);
+        return RefMatrix<const DerivedType, 1, Cols>(static_cast<const DerivedType &>(*this), row_start, 0);
     }
 
-    MatrixRef<DerivedType, Rows, 1> Column(int col_start)
+    RefMatrix<DerivedType, Rows, 1> Column(int col_start)
     {
-        return MatrixRef<DerivedType, Rows, 1>(static_cast<DerivedType &>(*this), 0, col_start);
+        return RefMatrix<DerivedType, Rows, 1>(static_cast<DerivedType &>(*this), 0, col_start);
     }
 
-    MatrixRef<const DerivedType, Rows, 1> Column(int col_start) const
+    RefMatrix<const DerivedType, Rows, 1> Column(int col_start) const
     {
-        return MatrixRef<const DerivedType, Rows, 1>(static_cast<const DerivedType &>(*this), 0, col_start);
+        return RefMatrix<const DerivedType, Rows, 1>(static_cast<const DerivedType &>(*this), 0, col_start);
     }
 
     MatrixTranspose<DerivedType> operator~() { return MatrixTranspose<DerivedType>(static_cast<DerivedType &>(*this)); }
@@ -145,4 +137,4 @@ struct MatrixBase
 }  // namespace BLA
 
 #include "impl/BasicLinearAlgebra.h"
-// #include "impl/NotSoBasicLinearAlgebra.h"
+#include "impl/NotSoBasicLinearAlgebra.h"

--- a/BasicLinearAlgebra.h
+++ b/BasicLinearAlgebra.h
@@ -8,139 +8,141 @@
 
 namespace BLA
 {
-template <int rows, int cols = 1, class MemT = Array<rows, cols, float>>
-class Matrix
+
+template <typename DerivedType, int rows, int cols, typename d_type>
+struct MatrixBase
 {
    public:
-    typedef MemT mem_t;
-    const static int Rows = rows;
-    const static int Cols = cols;
+    constexpr static int Rows = rows;
+    constexpr static int Cols = cols;
+    using DType = d_type;
 
-    MemT storage;
+    DType &operator()(int i, int j = 0)
+    {
+        assert(i < Rows && j < Cols);
+        return static_cast<DerivedType *>(this)->operator()(i, j);
+    }
 
-    // Constructors
-    Matrix<rows, cols, MemT>() = default;
+    DType operator()(int i, int j = 0) const
+    {
+        assert(i < Rows && j < Cols);
+        return static_cast<const DerivedType *>(this)->operator()(i, j);
+    }
 
-    Matrix<rows, cols, MemT>(MemT &d);
+    MatrixBase() = default;
 
-    template <class opMemT>
-    Matrix<rows, cols, MemT>(const Matrix<rows, cols, opMemT> &obj);
+    template <typename MatType>
+    MatrixBase(const MatrixBase<MatType, Rows, Cols, DType> &mat)
+    {
+        for (int i = 0; i < rows; ++i)
+        {
+            for (int j = 0; j < cols; ++j)
+            {
+                static_cast<DerivedType &>(*this)(i, j) = mat(i, j);
+            }
+        }
+    }
 
-    template <typename... TAIL>
-    Matrix(typename MemT::elem_t head, TAIL... args);
+    MatrixBase &operator=(const MatrixBase &mat)
+    {
+        for (int i = 0; i < rows; ++i)
+        {
+            for (int j = 0; j < cols; ++j)
+            {
+                static_cast<DerivedType &>(*this)(i, j) = mat(i, j);
+            }
+        }
 
-    // Assignment
-    template <class opMemT>
-    Matrix<rows, cols, MemT> &operator=(const Matrix<rows, cols, opMemT> &obj);
+        return static_cast<DerivedType &>(*this);
+    }
 
-    Matrix<rows, cols, MemT> &operator=(typename MemT::elem_t arr[rows][cols]);
+    template <typename MatType>
+    MatrixBase &operator=(const MatrixBase<MatType, Rows, Cols, DType> &mat)
+    {
+        for (int i = 0; i < rows; ++i)
+        {
+            for (int j = 0; j < cols; ++j)
+            {
+                static_cast<DerivedType &>(*this)(i, j) = mat(i, j);
+            }
+        }
 
-    Matrix<rows, cols, MemT> &Fill(const typename MemT::elem_t &val);
+        return static_cast<DerivedType &>(*this);
+    }
 
-    template <typename... TAIL>
-    void FillRowMajor(int start_idx, typename MemT::elem_t head, TAIL... tail);
-    void FillRowMajor(int start_idx);
+    DerivedType &operator=(DType elem)
+    {
+        for (int i = 0; i < rows; ++i)
+        {
+            for (int j = 0; j < cols; ++j)
+            {
+                static_cast<DerivedType &>(*this)(i, j) = elem;
+            }
+        }
 
-    // Element Access
-    typename MemT::elem_t &operator()(int row, int col = 0);
+        return static_cast<DerivedType &>(*this);
+    }
 
-    typename MemT::elem_t operator()(int row, int col = 0) const;
+    void Fill(const DType &val) { *this = val; }
 
-    template <int subRows, int subCols>
-    Matrix<subRows, subCols, Reference<MemT>> Submatrix(int top, int left);
+    template <int SubRows, int SubCols>
+    MatrixRef<DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start)
+    {
+        return MatrixRef<DerivedType, SubRows, SubCols>(static_cast<DerivedType &>(*this), row_start, col_start);
+    }
 
-    template <int subRows, int subCols>
-    Matrix<subRows, subCols, ConstReference<MemT>> Submatrix(int top, int left) const;
+    template <int SubRows, int SubCols>
+    MatrixRef<const DerivedType, SubRows, SubCols> Submatrix(int row_start, int col_start) const
+    {
+        return MatrixRef<const DerivedType, SubRows, SubCols>(static_cast<const DerivedType &>(*this), row_start,
+                                                              col_start);
+    }
 
-    Matrix<1, cols, Reference<MemT>> Row(int i);
-    Matrix<1, cols, ConstReference<MemT>> Row(int i) const;
+    MatrixRef<DerivedType, 1, Cols> Row(int row_start)
+    {
+        return MatrixRef<DerivedType, 1, Cols>(static_cast<DerivedType &>(*this), row_start, 0);
+    }
 
-    Matrix<rows, 1, Reference<MemT>> Column(int j);
-    Matrix<rows, 1, ConstReference<MemT>> Column(int j) const;
+    MatrixRef<const DerivedType, 1, Cols> Row(int row_start) const
+    {
+        return MatrixRef<const DerivedType, 1, Cols>(static_cast<const DerivedType &>(*this), row_start, 0);
+    }
 
-    // Concatenation
-    template <int operandCols, class opMemT>
-    Matrix<rows, cols + operandCols, HorzCat<cols, MemT, opMemT>> operator||(
-        const Matrix<rows, operandCols, opMemT> &obj) const;
+    MatrixRef<DerivedType, Rows, 1> Column(int col_start)
+    {
+        return MatrixRef<DerivedType, Rows, 1>(static_cast<DerivedType &>(*this), 0, col_start);
+    }
 
-    template <int operandRows, class opMemT>
-    Matrix<rows + operandRows, cols, VertCat<rows, MemT, opMemT>> operator&&(
-        const Matrix<operandRows, cols, opMemT> &obj) const;
+    MatrixRef<const DerivedType, Rows, 1> Column(int col_start) const
+    {
+        return MatrixRef<const DerivedType, Rows, 1>(static_cast<const DerivedType &>(*this), 0, col_start);
+    }
 
-    // Addition
-    template <class opMemT>
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator+(const Matrix<rows, cols, opMemT> &obj) const;
+    MatrixTranspose<DerivedType> operator~() { return MatrixTranspose<DerivedType>(static_cast<DerivedType &>(*this)); }
 
-    template <class opMemT>
-    Matrix<rows, cols, MemT> &operator+=(const Matrix<rows, cols, opMemT> &obj);
+    MatrixTranspose<const DerivedType> operator~() const
+    {
+        return MatrixTranspose<const DerivedType>(static_cast<const DerivedType &>(*this));
+    }
 
-    // Subtraction
-    template <class opMemT>
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator-(const Matrix<rows, cols, opMemT> &obj) const;
+    template <typename OperandType, int OperandCols>
+    HorizontalConcat<DerivedType, OperandType> operator||(
+        const MatrixBase<OperandType, Rows, OperandCols, DType> &obj) const
+    {
+        return HorizontalConcat<DerivedType, OperandType>(static_cast<const DerivedType &>(*this),
+                                                          static_cast<const OperandType &>(obj));
+    }
 
-    template <class opMemT>
-    Matrix<rows, cols, MemT> &operator-=(const Matrix<rows, cols, opMemT> &obj);
-
-    // Multiplication
-    template <int operandCols, class opMemT>
-    Matrix<rows, operandCols, Array<rows, operandCols, typename MemT::elem_t>> operator*(
-        const Matrix<cols, operandCols, opMemT> &operand) const;
-
-    template <class opMemT>
-    Matrix<rows, cols, MemT> &operator*=(const Matrix<rows, cols, opMemT> &operand);
-
-    // Negation
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator-() const;
-
-    // Transposition
-    Matrix<cols, rows, Trans<MemT>> operator~() const;
-
-    // Elementwise Operations
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator+(const typename MemT::elem_t k) const;
-
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator-(const typename MemT::elem_t k) const;
-
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator*(const typename MemT::elem_t k) const;
-
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> operator/(const typename MemT::elem_t k) const;
-
-    Matrix<rows, cols, MemT> &operator+=(const typename MemT::elem_t k);
-    Matrix<rows, cols, MemT> &operator-=(const typename MemT::elem_t k);
-    Matrix<rows, cols, MemT> &operator*=(const typename MemT::elem_t k);
-    Matrix<rows, cols, MemT> &operator/=(const typename MemT::elem_t k);
+    template <typename OperandType, int OperandRows>
+    VerticalConcat<DerivedType, OperandType> operator&&(
+        const MatrixBase<OperandType, OperandRows, Cols, DType> &obj) const
+    {
+        return VerticalConcat<DerivedType, OperandType>(static_cast<const DerivedType &>(*this),
+                                                        static_cast<const OperandType &>(obj));
+    }
 };
-
-template <int rows, int cols = 1, class ElemT = float>
-using ArrayMatrix = Matrix<rows, cols, Array<rows, cols, ElemT>>;
-
-template <int rows, int cols, class ElemT = float>
-using ArrayRef = Reference<Array<rows, cols, ElemT>>;
-
-template <int rows, int cols, class ParentMemT>
-using RefMatrix = Matrix<rows, cols, Reference<ParentMemT>>;
-
-template <int rows, int cols = rows, class ElemT = float>
-using Identity = Matrix<rows, cols, Eye<ElemT>>;
-
-template <int rows, int cols = 1, class ElemT = float>
-using Zeros = Matrix<rows, cols, Zero<ElemT>>;
-
-template <int rows, int cols = 1, class ElemT = float>
-using Ones = Matrix<rows, cols, One<ElemT>>;
-
-template <int rows, int cols, int tableSize, class ElemT = float>
-using SparseMatrix = Matrix<rows, cols, Sparse<cols, tableSize, ElemT>>;
-
-template <int dim, class ElemT = float>
-using PermutationMatrix = Matrix<dim, dim, Permutation<dim, ElemT>>;
-
-template <int rows, int cols, class MemT>
-using LowerTriangularDiagonalOnesMatrix = Matrix<rows, cols, LowerTriangleOnesDiagonal<MemT>>;
-
-template <int rows, int cols, class MemT>
-using UpperTriangularMatrix = Matrix<rows, cols, UpperTriangle<MemT>>;
 
 }  // namespace BLA
 
 #include "impl/BasicLinearAlgebra.h"
-#include "impl/NotSoBasicLinearAlgebra.h"
+// #include "impl/NotSoBasicLinearAlgebra.h"

--- a/ElementStorage.h
+++ b/ElementStorage.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iostream>
-
 namespace BLA
 {
 

--- a/ElementStorage.h
+++ b/ElementStorage.h
@@ -1,95 +1,192 @@
 #pragma once
 
+#include <iostream>
+
 namespace BLA
 {
-template <int rows, int cols = 1, class ElemT = float>
-struct Array
-{
-    typedef ElemT elem_t;
-    elem_t m[rows * cols];
 
-    elem_t &operator()(int row, int col) { return m[row * cols + col]; }
-    elem_t operator()(int row, int col) const { return m[row * cols + col]; }
+template <typename DerivedType, int rows, int cols, typename DType>
+struct MatrixBase;
+
+template <int Rows, int Cols = 1, typename DType = float>
+class Matrix : public MatrixBase<Matrix<Rows, Cols, DType>, Rows, Cols, DType>
+{
+   public:
+    DType storage[Rows * Cols];
+
+    DType &operator()(int i, int j = 0)
+    {
+        assert(i >= 0 && j >= 0 && i < Rows && j < Cols);
+        return storage[i * Cols + j];
+    }
+    DType operator()(int i, int j = 0) const
+    {
+        assert(i >= 0 && j >= 0 && i < Rows && j < Cols);
+        return storage[i * Cols + j];
+    }
+
+    Matrix() = default;
+
+    template <typename... TAIL>
+    Matrix(DType head, TAIL... args)
+    {
+        FillRowMajor(0, head, args...);
+    }
+
+    template <typename... TAIL>
+    void FillRowMajor(int start_idx, DType head, TAIL... tail)
+    {
+        static_assert(Rows * Cols > sizeof...(TAIL), "Too many arguments passed to FillRowMajor");
+
+        (*this)(start_idx / Cols, start_idx % Cols) = head;
+
+        FillRowMajor(++start_idx, tail...);
+    }
+
+    void FillRowMajor(int start_idx)
+    {
+        for (int i = start_idx; i < Rows * Cols; ++i)
+        {
+            (*this)(i / Cols, i % Cols) = 0.0;
+        }
+    }
+
+    template <typename DerivedType>
+    Matrix(const MatrixBase<DerivedType, Rows, Cols, DType> &mat)
+    {
+        static_cast<MatrixBase<Matrix<Rows, Cols, DType>, Rows, Cols, DType> &>(*this) = mat;
+    }
+
+    Matrix &operator=(const Matrix &mat)
+    {
+        static_cast<MatrixBase<Matrix<Rows, Cols, DType>, Rows, Cols, DType> &>(*this) = mat;
+        return *this;
+    }
 };
 
-template <class MemT>
-struct Reference
+template <int Rows, int Cols = 1, typename DType = float>
+class Zeros : public MatrixBase<Zeros<Rows, Cols, DType>, Rows, Cols, DType>
 {
-    typedef typename MemT::elem_t elem_t;
+   public:
+    DType operator()(int i, int j = 0) const { return 0.0; }
 
-    MemT &parent;
-    int rowOffset, colOffset;
-
-    Reference<MemT>(MemT &obj, int rowOff, int colOff) : parent(obj), rowOffset(rowOff), colOffset(colOff) {}
-
-    elem_t &operator()(int row, int col) { return parent(row + rowOffset, col + colOffset); }
-    elem_t operator()(int row, int col) const { return parent(row + rowOffset, col + colOffset); }
+    Zeros() = default;
 };
 
-template <class MemT>
-struct ConstReference
+template <int Rows, int Cols = 1, typename DType = float>
+class Ones : public MatrixBase<Ones<Rows, Cols, DType>, Rows, Cols, DType>
 {
-    typedef typename MemT::elem_t elem_t;
+   public:
+    DType operator()(int i, int j = 0) const { return 1.0; }
 
-    const MemT &parent;
-    int rowOffset, colOffset;
+    Ones() = default;
+};
 
-    ConstReference<MemT>(const MemT &obj, int rowOff, int colOff) : parent(obj), rowOffset(rowOff), colOffset(colOff) {}
-    ConstReference<MemT>(const ConstReference<MemT> &obj)
-        : parent(obj.parent), rowOffset(obj.rowOffset), colOffset(obj.colOffset)
+template <int Rows, int Cols = 1, typename DType = float>
+class Eye : public MatrixBase<Ones<Rows, Cols, DType>, Rows, Cols, DType>
+{
+   public:
+    DType operator()(int i, int j = 0) const { return i == j; }
+
+    Eye() = default;
+};
+
+template <typename RefType, int Rows, int Cols>
+class MatrixRef : public MatrixBase<MatrixRef<RefType, Rows, Cols>, Rows, Cols, typename RefType::DType>
+{
+    RefType &parent_;
+    const int row_offset_;
+    const int col_offset_;
+
+   public:
+    explicit MatrixRef(RefType &parent, int row_offset = 0, int col_offset = 0)
+        : parent_(parent), row_offset_(row_offset), col_offset_(col_offset)
     {
     }
 
-    elem_t operator()(int row, int col) const { return parent(row + rowOffset, col + colOffset); }
+    typename RefType::DType &operator()(int i, int j) { return parent_(i + row_offset_, j + col_offset_); }
+    typename RefType::DType operator()(int i, int j) const { return parent_(i + row_offset_, j + col_offset_); }
+
+    template <typename MatType>
+    MatrixRef &operator=(const MatType &mat)
+    {
+        static_cast<MatrixBase<MatrixRef<RefType, Rows, Cols>, Rows, Cols, typename RefType::DType> &>(*this) = mat;
+        return *this;
+    }
 };
 
-template <class ElemT>
-struct Eye
+template <typename RefType>
+class MatrixTranspose
+    : public MatrixBase<MatrixTranspose<RefType>, RefType::Cols, RefType::Rows, typename RefType::DType>
 {
-    typedef ElemT elem_t;
+    RefType &parent_;
 
-    elem_t operator()(int row, int col) const { return row == col; }
+   public:
+    explicit MatrixTranspose(RefType &parent) : parent_(parent) {}
+
+    typename RefType::DType &operator()(int i, int j) { return parent_(j, i); }
+    typename RefType::DType operator()(int i, int j) const { return parent_(j, i); }
+
+    template <typename MatType>
+    MatrixTranspose &operator=(const MatType &mat)
+    {
+        return static_cast<
+                   MatrixBase<MatrixTranspose<RefType>, RefType::Cols, RefType::Rows, typename RefType::DType> &>(
+                   *this) = mat;
+    }
 };
 
-template <class ElemT>
-struct Zero
+template <typename LeftType, typename RightType>
+struct HorizontalConcat : public MatrixBase<HorizontalConcat<LeftType, RightType>, LeftType::Rows,
+                                            LeftType::Cols + RightType::Cols, typename LeftType::DType>
 {
-    typedef ElemT elem_t;
+    const LeftType &left;
+    const RightType &right;
 
-    elem_t operator()(int row, int col) const { return 0; }
+    HorizontalConcat<LeftType, RightType>(const LeftType &l, const RightType &r) : left(l), right(r) {}
+
+    typename LeftType::DType operator()(int row, int col) const
+    {
+        return col < LeftType::Cols ? left(row, col) : right(row, col - LeftType::Cols);
+    }
 };
 
-template <class ElemT>
-struct One
+template <typename TopType, typename BottomType>
+struct VerticalConcat : public MatrixBase<VerticalConcat<TopType, BottomType>, TopType::Rows + BottomType::Rows,
+                                          TopType::Cols, typename TopType::DType>
 {
-    typedef ElemT elem_t;
+    const TopType &top;
+    const BottomType &bottom;
 
-    elem_t operator()(int row, int col) const { return 1; }
+    VerticalConcat<TopType, BottomType>(const TopType &t, const BottomType &b) : top(t), bottom(b) {}
+
+    typename TopType::DType operator()(int row, int col) const
+    {
+        return row < TopType::Rows ? top(row, col) : bottom(row - TopType::Rows, col);
+    }
 };
 
-template <int cols, int tableSize, class ElemT>
-struct Sparse
+template <int Rows, int Cols, typename DType, int TableSize>
+struct Sparse : public MatrixBase<Sparse<Rows, Cols, DType, TableSize>, Rows, Cols, DType>
 {
-    typedef ElemT elem_t;
-    const static int size = tableSize;
-    elem_t end;
+    DType end;
 
     struct Element
     {
         int row, col;
-        ElemT val;
+        DType val;
 
         Element() { row = col = -1; }
 
-    } table[tableSize];
+    } table[TableSize];
 
-    elem_t &operator()(int row, int col)
+    DType &operator()(int row, int col)
     {
-        int hash = (row * cols + col) % tableSize;
+        int hash = (row * Cols + col) % TableSize;
 
-        for (int i = 0; i < tableSize; i++)
+        for (int i = 0; i < TableSize; i++)
         {
-            Element &item = table[(hash + i) % tableSize];
+            Element &item = table[(hash + i) % TableSize];
 
             if (item.row == -1 || item.val == 0)
             {
@@ -107,13 +204,13 @@ struct Sparse
         return end;
     }
 
-    elem_t operator()(int row, int col) const
+    DType operator()(int row, int col) const
     {
-        int hash = (row * cols + col) % tableSize;
+        int hash = (row * Cols + col) % TableSize;
 
-        for (int i = 0; i < tableSize; i++)
+        for (int i = 0; i < TableSize; i++)
         {
-            const Element &item = table[(hash + i) % tableSize];
+            const Element &item = table[(hash + i) % TableSize];
 
             if (item.row == row && item.col == col)
             {
@@ -125,98 +222,62 @@ struct Sparse
     }
 };
 
-template <class MemT>
-struct Trans
-{
-    typedef typename MemT::elem_t elem_t;
-    const MemT &parent;
+// template <int dim, class ElemT>
+// struct Permutation
+// {
+//     typedef ElemT elem_t;
 
-    Trans<MemT>(const MemT &obj) : parent(obj) {}
-    Trans<MemT>(Trans<MemT> &obj) : parent(obj.parent) {}
+//     int idx[dim];
 
-    elem_t operator()(int row, int col) const { return parent(col, row); }
-};
+//     elem_t operator()(int row, int col) const { return idx[col] == row; }
+// };
 
-template <int leftCols, class LeftMemT, class RightMemT>
-struct HorzCat
-{
-    typedef typename LeftMemT::elem_t elem_t;
-    const LeftMemT &left;
-    const RightMemT &right;
+// template <class MemT>
+// struct LowerTriangleOnesDiagonal
+// {
+//     typedef typename MemT::elem_t elem_t;
 
-    HorzCat<leftCols, LeftMemT, RightMemT>(const LeftMemT &l, const RightMemT &r) : left(l), right(r) {}
+//     const MemT &parent;
 
-    elem_t operator()(int row, int col) const { return col < leftCols ? left(row, col) : right(row, col - leftCols); }
-};
+//     LowerTriangleOnesDiagonal<MemT>(const MemT &obj) : parent(obj) {}
 
-template <int topRows, class TopMemT, class BottomMemT>
-struct VertCat
-{
-    typedef typename TopMemT::elem_t elem_t;
-    const TopMemT &top;
-    const BottomMemT &bottom;
+//     elem_t operator()(int row, int col) const
+//     {
+//         if (row > col)
+//         {
+//             return parent(row, col);
+//         }
+//         else if (row == col)
+//         {
+//             return 1;
+//         }
+//         else
+//         {
+//             return 0;
+//         }
+//     }
+// };
 
-    VertCat<topRows, TopMemT, BottomMemT>(const TopMemT &t, const BottomMemT &b) : top(t), bottom(b) {}
+// template <class MemT>
+// struct UpperTriangle
+// {
+//     typedef typename MemT::elem_t elem_t;
 
-    elem_t operator()(int row, int col) const { return row < topRows ? top(row, col) : bottom(row - topRows, col); }
-};
+//     const MemT &parent;
 
-template <int dim, class ElemT>
-struct Permutation
-{
-    typedef ElemT elem_t;
+//     UpperTriangle<MemT>(const MemT &obj) : parent(obj) {}
 
-    int idx[dim];
-
-    elem_t operator()(int row, int col) const { return idx[col] == row; }
-};
-
-template <class MemT>
-struct LowerTriangleOnesDiagonal
-{
-    typedef typename MemT::elem_t elem_t;
-
-    const MemT &parent;
-
-    LowerTriangleOnesDiagonal<MemT>(const MemT &obj) : parent(obj) {}
-
-    elem_t operator()(int row, int col) const
-    {
-        if (row > col)
-        {
-            return parent(row, col);
-        }
-        else if (row == col)
-        {
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
-    }
-};
-
-template <class MemT>
-struct UpperTriangle
-{
-    typedef typename MemT::elem_t elem_t;
-
-    const MemT &parent;
-
-    UpperTriangle<MemT>(const MemT &obj) : parent(obj) {}
-
-    elem_t operator()(int row, int col) const
-    {
-        if (row <= col)
-        {
-            return parent(row, col);
-        }
-        else
-        {
-            return 0;
-        }
-    }
-};
+//     elem_t operator()(int row, int col) const
+//     {
+//         if (row <= col)
+//         {
+//             return parent(row, col);
+//         }
+//         else
+//         {
+//             return 0;
+//         }
+//     }
+// };
 
 }  // namespace BLA

--- a/README.md
+++ b/README.md
@@ -25,38 +25,34 @@ As well as some more advanced operations like Transposition, Concatenation and I
 
 By default, matrices are full of floats. If that doesn't suit your application, then you can specify what kind of datatype you'd like your matrix to be made of by passing it in to the class's parameters just after the dimensions like so:
 ```
-Matrix<3,2,Array<3,2,int> > D;
+Matrix<3,2,int> D;
 ```
 Not only that, the datatype needn't be just a POD (float, bool, int etc) but it can be any class or struct you define too. So if you'd like to do matrix math with your own custom class then you can, so long as it implements the operators for addition, subtraction etc. For example, if you wanted, you could write a class to hold an imaginary number and then you could make a matrix out of it like so:
 ```
-Matrix<2,2,Array<2,2,ImaginaryNumber> > Im;
+Matrix<2,2,ImaginaryNumber> Im;
 ```
 This turned out to have intersting implications when you specify the element type as another matrix. For more on that, have a look at the [Tensor](https://github.com/tomstewart89/BasicLinearAlgebra/blob/master/examples/Tensor/Tensor.ino) example.
 
-### Changing the Storage Policy
+### Changing the Way Elements are Retrieved
 
-By default, matrices store their elements in an C-style array which is kept inside the object. Every time you access one of the elements directly using the () operator or indirectly when you do some algebra, the matrix returns the appropriate element from that array. 
+By default, matrices store their elements in an C-style array which is kept inside the object. Every time you access one of the elements directly using the () operator or indirectly when you do some algebra, the matrix returns the appropriate element from that array.
 
 At times, it's handy to be able to instruct the matrix to do something else when asked to retrieve an element at a particular index. For example if you know that your matrix is very sparse (only a few elements are non-zero) then you can save yourself some memory and just store the non-zero elements and return zero when asked for anything else.
 
-If you like, you can override the way in which the elements for the matrix are stored by specifying a storage type that the Matrix class will refer to when accessing elements. For example, we can define a 2000x3000 matrix with a sparse storage policy like so:  
+If you like, you can override the way in which the elements for the matrix are stored. For example, we can define a 2000x3000 matrix with a sparse storage policy like so:
 ```
-Matrix<2000,3000, Sparse<3000,100,float> > sparseMatrix;
+SparseMatrix<2000, 3000, 100, float> > sparseMatrix;
 ```
-In this case the ```Sparse<3000,100,float>``` type is the memory storage which provides storage for 100 elements which are assumed to be embedded in a matrix having 3000 columns. You can find the implementation for this class in ElementStorage.h file, but long story short, it's a hashmap.
+In this case the ```SparseMatrix``` is a `Matrix` which provides storage for 100 elements which are assumed to be embedded in a matrix having 2000 rows and 3000 columns. You can find the implementation for this class in the ElementStorage.h file, but long story short, it's a hashmap.
 
-You can implement the memory storage in whatever way you like so long as it returns some piece of memory when passed a row/column index. For more on how to implement a memory storage, have a look at the  [CustomMatrix](https://github.com/tomstewart89/BasicLinearAlgebra/blob/master/examples/CustomMatrix/CustomMatrix.ino) example.
+You can implement the custom matrices in whatever way you like so long as it returns some element when passed a row/column index. For more on how to implement such a matrix, have a look at the [CustomMatrix](https://github.com/tomstewart89/BasicLinearAlgebra/blob/master/examples/CustomMatrix/CustomMatrix.ino) example.
 
 ### Reference Matrices
 
 One particularly useful part of being able to override the way matrices access their elements is that it lets us define reference matrices. Reference matrices don't actually own any memory themselves, instead they return the elements of another matrix when we access them. To create a reference matrix you can use the `Submatrix` method of the matrix class like so:
 ```
-auto ref = A.Submatrix<2,2>(1,0));
+auto ref = A.Submatrix<2,2>(1,0);
 ```
-Here, `ref` is a 2x2 matrix which returns the elements in the lower 2 rows of the 3x2 matrix A defined above. I've let the compiler infer the type of ref using the 'auto' keyword but if we were to write it out ourselves it'd be:
-```
-Matrix<2,2,float, Reference<float,Array<3,2> >;
-```
-Where `Reference<float,Array<3,2>` is a memory storage which takes a reference to a 3x2 matrix whose own memory storage is an Array (the default) of size 3x2.
+Here, `ref` is a 2x2 matrix which returns the elements in the lower 2 rows of the 3x2 matrix A defined above.
 
 In general, reference matrices are useful for isolating a subsection of a larger matrix. That lets us use just that section in matrix operations with other matrices of compatible dimensions, or to collectively assign a value to a particular section of a matrix. For more information on reference matrices check out the [References](https://github.com/tomstewart89/BasicLinearAlgebra/blob/master/examples/References/References.ino) example.

--- a/examples/CustomMatrix/CustomMatrix.ino
+++ b/examples/CustomMatrix/CustomMatrix.ino
@@ -13,29 +13,25 @@
  * diagonal matrix - a matrix whose elements are zero except for those along it's diagonal (row == column)
  */
 
-template <int dim, class ElemT>
-struct Diagonal
-{
-    mutable ElemT m[dim];
-    mutable ElemT offDiagonal;
-
-    // The only requirement on this class is that it implement the () operator like so:
-    typedef ElemT elem_t;
-
-    ElemT &operator()(int row, int col) const
-    {
-        // If it's on the diagonal and it's not larger than the matrix dimensions then return the element
-        if (row == col)
-            return m[row];
-        else
-            // Otherwise return a zero
-            return (offDiagonal = 0);
-    }
-};
-
 // All the functions in BasicLinearAlgebra are wrapped up inside the namespace BLA, so specify that we're using it like
 // so:
 using namespace BLA;
+
+template <int Dim>
+struct DiagonalMatrix : public MatrixBase<DiagonalMatrix<Dim>, Dim, Dim, float>
+{
+    Matrix<Dim, 1, float> diagonal;
+
+    float operator()(int row, int col) const
+    {
+        // If it's on the diagonal and it's not larger than the matrix dimensions then return the element
+        if (row == col)
+            return diagonal(row);
+        else
+            // Otherwise return a zero
+            return 0.f;
+    }
+};
 
 void setup()
 {
@@ -50,10 +46,10 @@ void setup()
 
     // Now let's declare a diagonal matrix. To do that we pass the Diagonal class from above along with whatever
     // template parameters as a template parameter to Matrix, like so:
-    BLA::Matrix<4, 4, Diagonal<4, float>> diag;
+    DiagonalMatrix<4> diag;
 
     // If we fill diag we'll get a matrix with all 1's along the diagonal, the identity matrix.
-    diag.Fill(1);
+    diag.diagonal.Fill(1);
 
     // So multiplying it with mat will do nothing:
     Serial << "still ones: " << diag * mat << "\n";
@@ -62,7 +58,7 @@ void setup()
     // (postmultiplication) of a matrix
 
     // So if we modify the diagonal
-    for (int i = 0; i < diag.Rows; i++) diag.storage(i, i) = i + 1;
+    for (int i = 0; i < diag.Rows; i++) diag.diagonal(i) = i + 1;
 
     // And multiply again, we'll see that the rows have been scaled
     Serial << "scaled rows: " << diag * mat;

--- a/examples/CustomMatrix/CustomMatrix.ino
+++ b/examples/CustomMatrix/CustomMatrix.ino
@@ -8,29 +8,36 @@
  * do a computation. Instead it'd be better to just store the non-zero elements and skip past the zeros when doing a
  * computation.
  *
- * For that reason, I've written the matrix class such that it's memory and the way it is accessed can be customised to
- * take advantage of whatever helpful properties the particular matrix might have. In this example we'll look at a
- * diagonal matrix - a matrix whose elements are zero except for those along it's diagonal (row == column)
+ * For that reason, I've written the matrix class such that we can customise the way a given matrix type retrieves its
+ * elements. In this example we'll look at a diagonal matrix - a matrix whose elements are zero except for those along
+ * it's diagonal (row == column).
  */
 
 // All the functions in BasicLinearAlgebra are wrapped up inside the namespace BLA, so specify that we're using it like
 // so:
 using namespace BLA;
 
-template <int Dim>
-struct DiagonalMatrix : public MatrixBase<DiagonalMatrix<Dim>, Dim, Dim, float>
+// To declare a custom matrix our class needs to inherit from MatrixBase. MatrixBase takes a few template parameters the
+// first of which is the custom matrix class itself. That's a bit confusing but just follow the template below and it'll
+// all work out!
+template <int Dim, typename DType = float>
+struct DiagonalMatrix : public MatrixBase<DiagonalMatrix<Dim>, Dim, Dim, DType>
 {
-    Matrix<Dim, 1, float> diagonal;
+    Matrix<Dim, 1, DType> diagonal;
 
-    float operator()(int row, int col) const
+    // For const matrices (ones whose elements can't be modified) you just need to implement this function:
+    DType operator()(int row, int col) const
     {
         // If it's on the diagonal and it's not larger than the matrix dimensions then return the element
         if (row == col)
             return diagonal(row);
         else
-            // Otherwise return a zero
-            return 0.f;
+            // Otherwise return zero
+            return 0.0f;
     }
+
+    // If you want to declare a matrix whose elements can be modified then you'll need to define this function:
+    // DType& operator()(int row, int col)
 };
 
 void setup()

--- a/examples/HowToUse/HowToUse.ino
+++ b/examples/HowToUse/HowToUse.ino
@@ -90,12 +90,12 @@ void setup()
 
     // Or as a more real life example, here's how you might calculate an updated state estimate for a third order state
     // space model:
-    BLA::Matrix<3> x;
-    BLA::Matrix<2> u;
-    BLA::Matrix<3, 2> G;
-    BLA::Matrix<3, 3> F;
+    BLA::Matrix<3> state;
+    BLA::Matrix<2> input;
+    BLA::Matrix<3, 2> input_matrix;
+    BLA::Matrix<3, 3> state_transition_matrix;
     float dt;
-    x += (F * x + G * u) * dt;
+    state += (state_transition_matrix * state + input_matrix * input) * dt;
 
     // Enjoy!
 }

--- a/examples/References/References.ino
+++ b/examples/References/References.ino
@@ -36,7 +36,7 @@ void setup()
 
     // So for example, to create a 4x4 reference to bigMatrix starting at element (4,2) the declaration would be as
     // follows:
-    RefMatrix<4, 4, Array<8, 8>> bigMatrixRef(bigMatrix.Submatrix<4, 4>(4, 2));
+    RefMatrix<BLA::Matrix<8, 8>, 4, 4> bigMatrixRef(bigMatrix.Submatrix<4, 4>(4, 2));
 
     // If we set the (0,0) element of bigMatrixRef, we're effectively setting the (4,2) element of bigMatrix. So let's
     // do that
@@ -51,7 +51,7 @@ void setup()
                                                         1.23,  3.21,  4.56,  8.76, 12.34, 34.56, 76.54, 21.09};
 
     // For all intents and purposes you can treat reference matrices as just regular matrices.
-    RefMatrix<2, 4, Array<8, 8>> anotherRef =
+    RefMatrix<BLA::Matrix<8, 8>, 2, 4> anotherRef =
         bigMatrix.Submatrix<2, 4>(2, 1);  // this creates a 2x4 reference matrix starting at element (2,1) of bigMatrix
 
     // You can fill them

--- a/examples/SolveLinearEquations/SolveLinearEquations.ino
+++ b/examples/SolveLinearEquations/SolveLinearEquations.ino
@@ -28,12 +28,12 @@ void setup()
     auto decomp = LUDecompose(A_decomp);
 
     // You can take a look at these matrices if you like:
-    decomp.P();  // P essentially rearranges the rows of the matrix that results when we multiply L by U
-    decomp.L();  // Will have ones along its diagonal and zeros above it
-    decomp.U();  // Will have zeros below its diagonal
+    decomp.P;  // P essentially rearranges the rows of the matrix that results when we multiply L by U
+    decomp.L;  // Will have ones along its diagonal and zeros above it
+    decomp.U;  // Will have zeros below its diagonal
 
     // And if we multiply them all together we'll recover the original A matrix:
-    Serial << "reconstructed A: " << decomp.P() * decomp.L() * decomp.U() << "\n";
+    Serial << "reconstructed A: " << decomp.P * decomp.L * decomp.U << "\n";
 
     // Once we've done the decomposition we can solve for x very efficiently:
     Matrix<6> x_lusolve = LUSolve(decomp, b);

--- a/examples/Tensor/Tensor.ino
+++ b/examples/Tensor/Tensor.ino
@@ -21,30 +21,27 @@ void setup()
     // for more). The Array type simply means that the Matrix stores it's elements in a big array of size rows x cols.
 
     // In any case, written in full, a Matrix declaration looks like this:
-    BLA::Matrix<3, 3, Array<3, 3, float>> floatA;
+    BLA::Matrix<3, 3, float> floatA;
 
     // The default underlying type of the Array class's array is float. If you want to use a different type, say int for
     // example, then just pass it as a template parameter like so:
-    BLA::Matrix<3, 3, Array<3, 3, int>> intA = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-    // I find this to be a bit cumbersome though so I've defined a template alias called ArrayMatrix which can be used
-    // like so:
-    ArrayMatrix<3, 3, int> intB;  // intA and intB are identical at this point
+    BLA::Matrix<3, 3, int> intA = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     // From here you'll be able to do everything you'd be able to do with a float Matrix, but with int precision and
     // memory useage.
 
     // You can actually pass any datatype you like to the template and it'll do it's best to make a Matrix out of it.
-    ArrayMatrix<3, 3, unsigned char> charA;
-    ArrayMatrix<3, 3, double> doubleA;  // etc
+    BLA::Matrix<3, 3, unsigned char> charA;
+    BLA::Matrix<3, 3, double> doubleA;  // etc
 
     // This includes parameters of type Matrix, meaning that you can declare matrices of more than two dimensions. For
     // example:
-    ArrayMatrix<4, 4, ArrayMatrix<4>> cubeA, cubeB;  // a 4x4x4 Matrix (3rd order tensor)
+    BLA::Matrix<4, 4, BLA::Matrix<4>> cubeA, cubeB;  // a 4x4x4 Matrix (3rd order tensor)
 
     // And so on:
-    ArrayMatrix<2, 2, ArrayMatrix<2, 2>> hyperA;                 // a 2x2x2x2 dimensional Matrix (4th order tensor)
-    ArrayMatrix<3, 3, ArrayMatrix<3, 3, Matrix<3, 3>>> tensorA;  // a 3x3x3x3x3x3 dimensional Matrix (6th order tensor)
+    BLA::Matrix<2, 2, BLA::Matrix<2, 2>> hyperA;  // a 2x2x2x2 dimensional Matrix (4th order tensor)
+    BLA::Matrix<3, 3, BLA::Matrix<3, 3, BLA::Matrix<3, 3>>>
+        tensorA;  // a 3x3x3x3x3x3 dimensional Matrix (6th order tensor)
 
     // You can access the elements of an arbitrary rank tensor with the brackets operator like so:
     cubeA(0, 1)(1) = cubeB(2, 3)(3) = 56.34;
@@ -55,7 +52,7 @@ void setup()
     cubeA + cubeB;
 
     // As does concatenation
-    ArrayMatrix<4, 8, ArrayMatrix<4>> cubeAleftOfcubeB = cubeA || cubeB;
+    BLA::Matrix<4, 8, BLA::Matrix<4>> cubeAleftOfcubeB = cubeA || cubeB;
 
     // You can also do multiplication on square tensors with an even rank
     for (int i = 0; i < 2; i++)
@@ -63,7 +60,7 @@ void setup()
             for (int k = 0; k < 2; k++)
                 for (int l = 0; l < 2; l++) hyperA(i, j)(k, l) = i + j + k + l;
 
-    ArrayMatrix<2, 2, ArrayMatrix<2, 2>> hyperB = (hyperA * hyperA);
+    BLA::Matrix<2, 2, BLA::Matrix<2, 2>> hyperB = (hyperA * hyperA);
 
     // Everything can be printed too
     Serial << "Hyper B: " << hyperB;

--- a/impl/BasicLinearAlgebra.h
+++ b/impl/BasicLinearAlgebra.h
@@ -8,308 +8,164 @@
 
 namespace BLA
 {
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT>::Matrix(MemT &d) : storage(d)
+template <typename MatAType, typename MatBType, int MatARows, int MatACols, int MatBCols, typename DType>
+Matrix<MatARows, MatBCols, DType> operator*(const MatrixBase<MatAType, MatARows, MatACols, DType> &matA,
+                                            const MatrixBase<MatBType, MatACols, MatBCols, DType> &matB)
 {
-}
+    Matrix<MatARows, MatBCols, DType> ret;
 
-template <int rows, int cols, class MemT>
-template <typename... TAIL>
-Matrix<rows, cols, MemT>::Matrix(typename MemT::elem_t head, TAIL... args)
-{
-    FillRowMajor(0, head, args...);
-}
-
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, MemT>::Matrix(const Matrix<rows, cols, opMemT> &obj)
-{
-    *this = obj;
-}
-
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator=(const Matrix<rows, cols, opMemT> &obj)
-{
-    for (int i = 0; i < rows; i++)
-        for (int j = 0; j < cols; j++) (*this)(i, j) = obj(i, j);
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator=(typename MemT::elem_t arr[rows][cols])
-{
-    for (int i = 0; i < rows; i++)
-        for (int j = 0; j < cols; j++) (*this)(i, j) = arr[i][j];
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::Fill(const typename MemT::elem_t &val)
-{
-    for (int i = 0; i < rows; i++)
-        for (int j = 0; j < cols; j++) (*this)(i, j) = val;
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-template <typename... TAIL>
-void Matrix<rows, cols, MemT>::FillRowMajor(int start_idx, typename MemT::elem_t head, TAIL... tail)
-{
-    static_assert(rows * cols > sizeof...(TAIL), "Too many arguments passed to FillRowMajor");
-
-    (*this)(start_idx / cols, start_idx % cols) = head;
-
-    FillRowMajor(++start_idx, tail...);
-}
-
-template <int rows, int cols, class MemT>
-void Matrix<rows, cols, MemT>::FillRowMajor(int start_idx)
-{
-    for (int i = start_idx; i < rows * cols; ++i)
+    for (int i = 0; i < MatARows; ++i)
     {
-        (*this)(i / cols, i % cols) = 0.0;
+        for (int j = 0; j < MatBCols; ++j)
+        {
+            if (MatACols > 0)
+            {
+                ret(i, j) = matA(i, 0) * matB(0, j);
+            }
+
+            for (int k = 1; k < MatACols; k++)
+            {
+                ret(i, j) += matA(i, k) * matB(k, j);
+            }
+        }
     }
-}
-
-template <int rows, int cols, class MemT>
-typename MemT::elem_t &Matrix<rows, cols, MemT>::operator()(int row, int col)
-{
-    return storage(row, col);
-}
-
-template <int rows, int cols, class MemT>
-typename MemT::elem_t Matrix<rows, cols, MemT>::operator()(int row, int col) const
-{
-    return storage(row, col);
-}
-
-template <int rows, int cols, class MemT>
-template <int subRows, int subCols>
-Matrix<subRows, subCols, Reference<MemT>> Matrix<rows, cols, MemT>::Submatrix(int top, int left)
-{
-    Reference<MemT> ref(storage, top, left);
-    return Matrix<subRows, subCols, Reference<MemT>>(ref);
-}
-
-template <int rows, int cols, class MemT>
-template <int subRows, int subCols>
-Matrix<subRows, subCols, ConstReference<MemT>> Matrix<rows, cols, MemT>::Submatrix(int top, int left) const
-{
-    ConstReference<MemT> ref(storage, top, left);
-    return Matrix<subRows, subCols, ConstReference<MemT>>(ref);
-}
-
-template <int rows, int cols, class MemT>
-Matrix<1, cols, Reference<MemT>> Matrix<rows, cols, MemT>::Row(int i)
-{
-    return Submatrix<1, cols>(i, 0);
-}
-
-template <int rows, int cols, class MemT>
-Matrix<1, cols, ConstReference<MemT>> Matrix<rows, cols, MemT>::Row(int i) const
-{
-    return Submatrix<1, cols>(i, 0);
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, 1, Reference<MemT>> Matrix<rows, cols, MemT>::Column(int j)
-{
-    return Submatrix<rows, 1>(0, j);
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, 1, ConstReference<MemT>> Matrix<rows, cols, MemT>::Column(int j) const
-{
-    return Submatrix<rows, 1>(0, j);
-}
-
-template <int rows, int cols, class MemT>
-template <int operandCols, class opMemT>
-Matrix<rows, cols + operandCols, HorzCat<cols, MemT, opMemT>> Matrix<rows, cols, MemT>::operator||(
-    const Matrix<rows, operandCols, opMemT> &obj) const
-{
-    HorzCat<cols, MemT, opMemT> ref(storage, obj.storage);
-    return Matrix<rows, cols + operandCols, HorzCat<cols, MemT, opMemT>>(ref);
-}
-
-template <int rows, int cols, class MemT>
-template <int operandRows, class opMemT>
-Matrix<rows + operandRows, cols, VertCat<rows, MemT, opMemT>> Matrix<rows, cols, MemT>::operator&&(
-    const Matrix<operandRows, cols, opMemT> &obj) const
-{
-    VertCat<rows, MemT, opMemT> ref(storage, obj.storage);
-    return Matrix<rows + operandRows, cols, VertCat<rows, MemT, opMemT>>(ref);
-}
-
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator+(
-    const Matrix<rows, cols, opMemT> &obj) const
-{
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
-    ret += obj;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator+=(const Matrix<rows, cols, opMemT> &obj)
+template <typename MatAType, typename MatBType, int MatARows, int MatACols, int MatBCols, typename DType>
+MatrixBase<MatAType, MatARows, MatACols, DType> &operator*=(MatrixBase<MatAType, MatARows, MatACols, DType> &matA,
+                                                            const MatrixBase<MatBType, MatACols, MatBCols, DType> &matB)
 {
-    for (int i = 0; i < rows; i++)
+    matA = matA * matB;
+    return matA;
+}
+
+template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
+MatrixBase<MatAType, Rows, Cols, DType> &operator+=(MatrixBase<MatAType, Rows, Cols, DType> &matA,
+                                                    const MatrixBase<MatBType, Cols, Cols, DType> &matB)
+{
+    for (int i = 0; i < Rows; ++i)
     {
-        for (int j = 0; j < cols; j++)
+        for (int j = 0; j < Cols; ++j)
         {
-            storage(i, j) += obj.storage(i, j);
+            matA(i, j) += matB(i, j);
         }
     }
 
-    return *this;
+    return matA;
 }
 
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator-(
-    const Matrix<rows, cols, opMemT> &obj) const
+template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
+MatrixBase<MatAType, Rows, Cols, DType> &operator-=(MatrixBase<MatAType, Rows, Cols, DType> &matA,
+                                                    const MatrixBase<MatBType, Cols, Cols, DType> &matB)
 {
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
-    ret -= obj;
-    return ret;
-}
-
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator-=(const Matrix<rows, cols, opMemT> &obj)
-{
-    for (int i = 0; i < rows; i++)
+    for (int i = 0; i < Rows; ++i)
     {
-        for (int j = 0; j < cols; j++)
+        for (int j = 0; j < Cols; ++j)
         {
-            storage(i, j) -= obj.storage(i, j);
+            matA(i, j) -= matB(i, j);
         }
     }
 
-    return *this;
+    return matA;
 }
 
-template <int rows, int cols, class MemT>
-template <int operandCols, class opMemT>
-Matrix<rows, operandCols, Array<rows, operandCols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator*(
-    const Matrix<cols, operandCols, opMemT> &operand) const
+template <typename MatType, int Rows, int Cols, typename DType>
+MatrixBase<MatType, Rows, Cols, DType> &operator*=(MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
-    Matrix<rows, operandCols, Array<rows, operandCols, typename MemT::elem_t>> ret;
-
-    for (int i = 0; i < rows; i++)
-        for (int j = 0; j < operandCols; j++)
+    for (int i = 0; i < Rows; ++i)
+    {
+        for (int j = 0; j < Cols; ++j)
         {
-            if (cols > 0) ret.storage(i, j) = storage(i, 0) * operand.storage(0, j);
-
-            for (int k = 1; k < cols; k++) ret.storage(i, j) += storage(i, k) * operand.storage(k, j);
+            mat(i, j) *= k;
         }
+    }
+    return mat;
+}
 
+template <typename MatType, int Rows, int Cols, typename DType>
+MatrixBase<MatType, Rows, Cols, DType> &operator/=(MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
+{
+    for (int i = 0; i < Rows; ++i)
+    {
+        for (int j = 0; j < Cols; ++j)
+        {
+            mat(i, j) /= k;
+        }
+    }
+    return mat;
+}
+template <typename MatType, int Rows, int Cols, typename DType>
+MatrixBase<MatType, Rows, Cols, DType> &operator+=(MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
+{
+    for (int i = 0; i < Rows; ++i)
+    {
+        for (int j = 0; j < Cols; ++j)
+        {
+            mat(i, j) += k;
+        }
+    }
+    return mat;
+}
+template <typename MatType, int Rows, int Cols, typename DType>
+MatrixBase<MatType, Rows, Cols, DType> &operator-=(MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
+{
+    for (int i = 0; i < Rows; ++i)
+    {
+        for (int j = 0; j < Cols; ++j)
+        {
+            mat(i, j) -= k;
+        }
+    }
+    return mat;
+}
+
+template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator+(const MatrixBase<MatAType, Rows, Cols, DType> &matA,
+                                    const MatrixBase<MatBType, Rows, Cols, DType> &matB)
+{
+    Matrix<Rows, Cols, DType> ret = matA;
+    ret += matB;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-template <class opMemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator*=(const Matrix<rows, cols, opMemT> &operand)
+template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator-(const MatrixBase<MatAType, Rows, Cols, DType> &matA,
+                                    const MatrixBase<MatBType, Rows, Cols, DType> &matB)
 {
-    Matrix<rows, cols, MemT> tmp(*this);
-    *this = tmp * operand;
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator-() const
-{
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret;
-
-    for (int i = 0; i < rows; i++)
-        for (int j = 0; j < cols; j++) ret(i, j) = -(*this)(i, j);
-
+    Matrix<Rows, Cols, DType> ret = matA;
+    ret -= matB;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-Matrix<cols, rows, Trans<MemT>> Matrix<rows, cols, MemT>::operator~() const
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator+(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
-    Trans<MemT> ref(storage);
-    Matrix<cols, rows, Trans<MemT>> tmp(ref);
-
-    return tmp;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator+=(const typename MemT::elem_t k)
-{
-    for (int i = 0; i < rows; ++i)
-        for (int j = 0; j < cols; ++j) storage(i, j) += k;
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator-=(const typename MemT::elem_t k)
-{
-    for (int i = 0; i < rows; ++i)
-        for (int j = 0; j < cols; ++j) storage(i, j) -= k;
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator*=(const typename MemT::elem_t k)
-{
-    for (int i = 0; i < rows; ++i)
-        for (int j = 0; j < cols; ++j) storage(i, j) *= k;
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, MemT> &Matrix<rows, cols, MemT>::operator/=(const typename MemT::elem_t k)
-{
-    for (int i = 0; i < rows; ++i)
-        for (int j = 0; j < cols; ++j) storage(i, j) /= k;
-
-    return *this;
-}
-
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator+(
-    const typename MemT::elem_t k) const
-{
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
+    Matrix<Rows, Cols, DType> ret = mat;
     ret += k;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator-(
-    const typename MemT::elem_t k) const
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator-(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
+    Matrix<Rows, Cols, DType> ret = mat;
     ret -= k;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator*(
-    const typename MemT::elem_t k) const
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator*(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
+    Matrix<Rows, Cols, DType> ret = mat;
     ret *= k;
     return ret;
 }
 
-template <int rows, int cols, class MemT>
-Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> Matrix<rows, cols, MemT>::operator/(
-    const typename MemT::elem_t k) const
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator/(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
-    Matrix<rows, cols, Array<rows, cols, typename MemT::elem_t>> ret(*this);
+    Matrix<Rows, Cols, DType> ret = mat;
     ret /= k;
     return ret;
 }
@@ -339,18 +195,18 @@ inline Print &operator<<(Print &strm, const char obj)
 }
 
 // Stream inserter operator for printing to strings or the serial port
-template <int rows, int cols, class MemT>
-Print &operator<<(Print &strm, const Matrix<rows, cols, MemT> &obj)
+template <typename DerivedType, int Rows, int Cols, typename DType>
+Print &operator<<(Print &strm, const MatrixBase<DerivedType, Rows, Cols, DType> &mat)
 {
     strm << '[';
 
-    for (int i = 0; i < rows; i++)
+    for (int i = 0; i < Rows; i++)
     {
         strm << '[';
 
-        for (int j = 0; j < cols; j++) strm << obj(i, j) << ((j == cols - 1) ? ']' : ',');
+        for (int j = 0; j < Cols; j++) strm << mat(i, j) << ((j == Cols - 1) ? ']' : ',');
 
-        strm << (i == rows - 1 ? ']' : ',');
+        strm << (i == Rows - 1 ? ']' : ',');
     }
     return strm;
 }

--- a/impl/BasicLinearAlgebra.h
+++ b/impl/BasicLinearAlgebra.h
@@ -42,7 +42,7 @@ MatrixBase<MatAType, MatARows, MatACols, DType> &operator*=(MatrixBase<MatAType,
 
 template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
 MatrixBase<MatAType, Rows, Cols, DType> &operator+=(MatrixBase<MatAType, Rows, Cols, DType> &matA,
-                                                    const MatrixBase<MatBType, Cols, Cols, DType> &matB)
+                                                    const MatrixBase<MatBType, Rows, Cols, DType> &matB)
 {
     for (int i = 0; i < Rows; ++i)
     {
@@ -57,7 +57,7 @@ MatrixBase<MatAType, Rows, Cols, DType> &operator+=(MatrixBase<MatAType, Rows, C
 
 template <typename MatAType, typename MatBType, int Rows, int Cols, typename DType>
 MatrixBase<MatAType, Rows, Cols, DType> &operator-=(MatrixBase<MatAType, Rows, Cols, DType> &matA,
-                                                    const MatrixBase<MatBType, Cols, Cols, DType> &matB)
+                                                    const MatrixBase<MatBType, Rows, Cols, DType> &matB)
 {
     for (int i = 0; i < Rows; ++i)
     {

--- a/impl/NotSoBasicLinearAlgebra.h
+++ b/impl/NotSoBasicLinearAlgebra.h
@@ -15,26 +15,22 @@ struct LUDecomposition
 {
     bool singular;
     typename ParentType::DType parity;
-    PermutationMatrix<Dim, typename ParentType::DType> permutation;
-    LowerTriangularDiagonalOnesMatrix<ParentType> lower;
-    UpperTriangularMatrix<ParentType> upper;
+    PermutationMatrix<Dim, typename ParentType::DType> P;
+    LowerTriangularDiagonalOnesMatrix<ParentType> L;
+    UpperTriangularMatrix<ParentType> U;
 
     LUDecomposition(MatrixBase<ParentType, ParentType::Rows, ParentType::Cols, typename ParentType::DType> &A)
-        : lower(A), upper(A)
+        : L(static_cast<ParentType &>(A)), U(static_cast<ParentType &>(A))
     {
         static_assert(ParentType::Rows == ParentType::Cols);
     }
-
-    PermutationMatrix<ParentType::Rows, typename ParentType::DType> P() { return permutation; }
-    LowerTriangularDiagonalOnesMatrix<ParentType> L() { return lower; }
-    UpperTriangularMatrix<ParentType> U() { return upper; }
 };
 
 template <typename ParentType, int Dim>
 LUDecomposition<Dim, ParentType> LUDecompose(MatrixBase<ParentType, Dim, Dim, typename ParentType::DType> &A)
 {
     LUDecomposition<Dim, ParentType> decomp(A);
-    auto &idx = decomp.permutation.idx;
+    auto &idx = decomp.P.idx;
     decomp.parity = 1.0;
 
     for (int i = 0; i < Dim; ++i)
@@ -151,8 +147,8 @@ Matrix<Dim, 1, typename BType::DType> LUSolve(const LUDecomposition<Dim, LUType>
 {
     Matrix<Dim, 1, typename BType::DType> x, tmp;
 
-    auto &idx = decomp.permutation.idx;
-    auto &LU = decomp.lower.parent;
+    auto &idx = decomp.P.idx;
+    auto &LU = decomp.L.parent;
 
     // Forward substitution to solve L * y = b
     for (int i = 0; i < Dim; ++i)
@@ -239,7 +235,7 @@ typename ParentType::DType Determinant(const MatrixBase<ParentType, Dim, Dim, ty
 
     for (int i = 0; i < Dim; ++i)
     {
-        det *= decomp.upper(i, i);
+        det *= decomp.U(i, i);
     }
 
     return det;

--- a/impl/NotSoBasicLinearAlgebra.h
+++ b/impl/NotSoBasicLinearAlgebra.h
@@ -147,9 +147,8 @@ LUDecomposition<dim, MemT> LUDecompose(Matrix<dim, dim, MemT> &A)
     return decomp;
 }
 
-template <int dim, class MemT1, class MemT2>
-ArrayMatrix<dim, 1, typename MemT2::elem_t> LUSolve(const LUDecomposition<dim, MemT1> &decomp,
-                                                    const Matrix<dim, 1, MemT2> &b)
+template <int dim, class LUType, class BType>
+Matrix<dim, 1, > LUSolve(const LUDecomposition<dim, MemT1> &decomp, const Matrix<dim, 1, MemT2> &b)
 {
     ArrayMatrix<dim, 1, typename MemT2::elem_t> x, tmp;
 

--- a/test/Arduino.h
+++ b/test/Arduino.h
@@ -1,21 +1,21 @@
 #pragma once
 
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
-#include <algorithm>
 
 struct Print
 {
     std::stringstream buf;
 
     template <typename T>
-    void print(const T &obj)
+    void print(const T& obj)
     {
         buf << obj;
     }
 
     template <typename T>
-    void println(const T &obj)
+    void println(const T& obj)
     {
         buf << obj << std::endl;
     }
@@ -26,7 +26,7 @@ struct Print
         buf.str("");
     }
 
-    Print& operator<< (std::ostream& (*pf)(std::ostream&))
+    Print& operator<<(std::ostream& (*pf)(std::ostream&))
     {
         buf << pf;
         return *this;
@@ -34,4 +34,5 @@ struct Print
 
 } Serial;
 
-using std::endl, std::max;
+using std::endl;
+using std::max;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,14 +18,14 @@ include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/..")
 add_executable(test_arithmetic test_arithmetic.cpp)
 target_link_libraries(test_arithmetic gtest_main)
 
-add_executable(test_linear_algebra test_linear_algebra.cpp)
-target_link_libraries(test_linear_algebra gtest_main)
+# add_executable(test_linear_algebra test_linear_algebra.cpp)
+# target_link_libraries(test_linear_algebra gtest_main)
 
-add_executable(test_examples test_examples.cpp)
-target_link_libraries(test_examples gtest_main)
+# add_executable(test_examples test_examples.cpp)
+# target_link_libraries(test_examples gtest_main)
 
 include(GoogleTest)
 
 gtest_discover_tests(test_arithmetic)
-gtest_discover_tests(test_linear_algebra)
-gtest_discover_tests(test_examples)
+# gtest_discover_tests(test_linear_algebra)
+# gtest_discover_tests(test_examples)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,14 +18,14 @@ include_directories("${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/..")
 add_executable(test_arithmetic test_arithmetic.cpp)
 target_link_libraries(test_arithmetic gtest_main)
 
-# add_executable(test_linear_algebra test_linear_algebra.cpp)
-# target_link_libraries(test_linear_algebra gtest_main)
+add_executable(test_linear_algebra test_linear_algebra.cpp)
+target_link_libraries(test_linear_algebra gtest_main)
 
-# add_executable(test_examples test_examples.cpp)
-# target_link_libraries(test_examples gtest_main)
+add_executable(test_examples test_examples.cpp)
+target_link_libraries(test_examples gtest_main)
 
 include(GoogleTest)
 
 gtest_discover_tests(test_arithmetic)
-# gtest_discover_tests(test_linear_algebra)
-# gtest_discover_tests(test_examples)
+gtest_discover_tests(test_linear_algebra)
+gtest_discover_tests(test_examples)

--- a/test/test_arithmetic.cpp
+++ b/test/test_arithmetic.cpp
@@ -19,10 +19,6 @@ TEST(Arithmetic, BraceInitialisation)
     EXPECT_FLOAT_EQ(C(0, 1), 5.98);
     EXPECT_FLOAT_EQ(C(1, 0), 0.0);
     EXPECT_FLOAT_EQ(C(1, 1), 0.0);
-
-    Matrix<3, 3> D{0};
-
-    EXPECT_FLOAT_EQ(Norm(D), 0.0);
 }
 
 TEST(Arithmetic, Fill)
@@ -41,8 +37,8 @@ TEST(Arithmetic, Fill)
 
 TEST(Arithmetic, OnesTest)
 {
-    Matrix<2, 2> A = Zeros<2,2>();
-    Matrix<2, 2> B = Ones<2,2>();
+    Matrix<2, 2> A = Zeros<2, 2>();
+    Matrix<2, 2> B = Ones<2, 2>();
 
     for (int i = 0; i < 2; ++i)
     {
@@ -86,12 +82,12 @@ TEST(Arithmetic, AdditionSubtraction)
 
 TEST(Arithmetic, ElementwiseOperations)
 {
-    Matrix<3, 3> A = {3.25, 5.67, 8.67, 4.55, 7.23, 9.00, 2.35, 5.73, 10.56};
+    Matrix<3, 3> A = {3.25f, 5.67f, 8.67f, 4.55f, 7.23f, 9.00f, 2.35f, 5.73f, 10.56f};
 
-    auto C = A + 2.5;
-    auto D = A - 3.7;
-    auto E = A * 1.2;
-    auto F = A / 6.7;
+    auto C = A + 2.5f;
+    auto D = A - 3.7f;
+    auto E = A * 1.2f;
+    auto F = A / 6.7f;
 
     for (int i = 0; i < 2; ++i)
     {
@@ -148,8 +144,8 @@ TEST(Arithmetic, Concatenation)
 
     Matrix<3, 3> B = {6.54, 3.66, 2.95, 3.22, 7.54, 5.12, 8.98, 9.99, 1.56};
 
-    Matrix<3, 6> AleftOfB = A || B;
-    Matrix<6, 3> AonTopOfB = A && B;
+    auto AleftOfB = A || B;
+    auto AonTopOfB = A && B;
 
     for (int i = 0; i < 3; ++i)
     {

--- a/test/test_arithmetic.cpp
+++ b/test/test_arithmetic.cpp
@@ -80,6 +80,25 @@ TEST(Arithmetic, AdditionSubtraction)
     }
 }
 
+TEST(Arithmetic, OtherDTypes)
+{
+    Matrix<3, 3, int> A = {3, 6, 5, 8, 34, 7, 3, 7, 9};
+
+    Matrix<3, 3, bool> B = {true, false, true, true, false, false};
+
+    auto C = A + 5;
+    auto D = B * false;
+
+    for (int i = 0; i < 2; ++i)
+    {
+        for (int j = 0; j < 2; ++j)
+        {
+            EXPECT_EQ(C(i, j), A(i, j) + 5);
+            EXPECT_FALSE(D(i, j));
+        }
+    }
+}
+
 TEST(Arithmetic, ElementwiseOperations)
 {
     Matrix<3, 3> A = {3.25f, 5.67f, 8.67f, 4.55f, 7.23f, 9.00f, 2.35f, 5.73f, 10.56f};
@@ -97,6 +116,22 @@ TEST(Arithmetic, ElementwiseOperations)
             EXPECT_FLOAT_EQ(D(i, j), A(i, j) - 3.7);
             EXPECT_FLOAT_EQ(E(i, j), A(i, j) * 1.2);
             EXPECT_FLOAT_EQ(F(i, j), A(i, j) / 6.7);
+        }
+    }
+
+    C -= 2.5f;
+    D += 3.7f;
+    E /= 1.2f;
+    F *= 6.7f;
+
+    for (int i = 0; i < 2; ++i)
+    {
+        for (int j = 0; j < 2; ++j)
+        {
+            EXPECT_FLOAT_EQ(C(i, j), A(i, j));
+            EXPECT_FLOAT_EQ(D(i, j), A(i, j));
+            EXPECT_FLOAT_EQ(E(i, j), A(i, j));
+            EXPECT_FLOAT_EQ(F(i, j), A(i, j));
         }
     }
 }

--- a/test/test_linear_algebra.cpp
+++ b/test/test_linear_algebra.cpp
@@ -73,9 +73,9 @@ TEST(LinearAlgebra, Inversion)
 
 TEST(LinearAlgebra, DoublePrecisionInverse)
 {
-    ArrayMatrix<6, 6, double> A = {1. / 48.,  0,          0,         0, 0, 0, 0, 1. / 48.,  0,        0,       0, 0, 0,
-                                   -1. / 48., 1. / 48.,   0,         0, 0, 0, 0, 0,         1. / 24., 0,       0, 0, 0,
-                                   0,         -1. / 28.8, 1. / 28.8, 0, 0, 0, 0, -1. / 12., 1. / 24., 1. / 24.};
+    Matrix<6, 6, double> A = {1. / 48.,  0,          0,         0, 0, 0, 0, 1. / 48.,  0,        0,       0, 0, 0,
+                              -1. / 48., 1. / 48.,   0,         0, 0, 0, 0, 0,         1. / 24., 0,       0, 0, 0,
+                              0,         -1. / 28.8, 1. / 28.8, 0, 0, 0, 0, -1. / 12., 1. / 24., 1. / 24.};
 
     auto A_inv = Inverse(A * 1.8);
 
@@ -101,18 +101,19 @@ TEST(Arithmetic, Determinant)
 }
 
 template <typename SparseMatA, typename SparseMatB, int OutTableSize = 100>
-SparseMatrix<SparseMatA::Rows, SparseMatB::Cols, OutTableSize> sparse_mul(const SparseMatA &A, const SparseMatB &B)
+SparseMatrix<SparseMatA::Rows, SparseMatB::Cols, typename SparseMatA::DType, OutTableSize> sparse_mul(
+    const SparseMatA &A, const SparseMatB &B)
 {
     static_assert(A.Cols == B.Rows);
 
-    SparseMatrix<A.Rows, B.Cols, OutTableSize> out;
+    SparseMatrix<A.Rows, B.Cols, typename SparseMatA::DType, OutTableSize> out;
 
-    for (int i = 0; i < A.storage.size; ++i)
+    for (int i = 0; i < SparseMatA::Size; ++i)
     {
-        for (int j = 0; j < B.storage.size; ++j)
+        for (int j = 0; j < SparseMatB::Size; ++j)
         {
-            const auto &elem_a = A.storage.table[i];
-            const auto &elem_b = B.storage.table[j];
+            const auto &elem_a = A.table[i];
+            const auto &elem_b = B.table[j];
 
             if (elem_a.row >= 0 && elem_b.row >= 0)
             {
@@ -126,15 +127,13 @@ SparseMatrix<SparseMatA::Rows, SparseMatB::Cols, OutTableSize> sparse_mul(const 
 
 TEST(Examples, SparseMatrix)
 {
-    SparseMatrix<1, 3000, 100> A;
-    SparseMatrix<3000, 1, 100> B;
+    SparseMatrix<1, 3000, float, 100> A;
+    SparseMatrix<3000, 1, float, 100> B;
 
     A(0, 1000) = 5.0;
     B(1000, 0) = 5.0;
 
     auto C = sparse_mul(A, B);
-
-    Matrix<2000, 3000, Sparse<3000, 100, float> > sparseMatrix;
 
     EXPECT_EQ(C(0, 0), 25.0);
 }

--- a/test/test_linear_algebra.cpp
+++ b/test/test_linear_algebra.cpp
@@ -15,7 +15,7 @@ TEST(LinearAlgebra, LUDecomposition)
 
     EXPECT_FALSE(decomp.singular);
 
-    auto A_reconstructed = decomp.P() * decomp.L() * decomp.U();
+    auto A_reconstructed = decomp.P * decomp.L * decomp.U;
 
     for (int i = 0; i < A.Rows; ++i)
     {


### PR DESCRIPTION
The current design had a few flaws:

* MemTypes were required to define an `elem_t`
* Really difficult to declare MemTypes that were const, leading to lots of `mutable`s everywhere

This PR switches the MemT over to a CRTP design which is cleaner and allows lots more operations to take place at compile time.