### PR TITLE
Elementwise operations with swapped order

### DIFF
--- a/impl/BasicLinearAlgebra.h
+++ b/impl/BasicLinearAlgebra.h
@@ -147,11 +147,23 @@ Matrix<Rows, Cols, DType> operator+(const MatrixBase<MatType, Rows, Cols, DType>
 }
 
 template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator+(const DType k, const MatrixBase<MatType, Rows, Cols, DType> &mat)
+{
+    return mat + k;
+}
+
+template <typename MatType, int Rows, int Cols, typename DType>
 Matrix<Rows, Cols, DType> operator-(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
     Matrix<Rows, Cols, DType> ret = mat;
     ret -= k;
     return ret;
+}
+
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator-(const DType k, const MatrixBase<MatType, Rows, Cols, DType> &mat)
+{
+    return (-mat) + k;
 }
 
 template <typename MatType, int Rows, int Cols, typename DType>
@@ -163,10 +175,30 @@ Matrix<Rows, Cols, DType> operator*(const MatrixBase<MatType, Rows, Cols, DType>
 }
 
 template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator*(const DType k, const MatrixBase<MatType, Rows, Cols, DType> &mat)
+{
+    return mat * k;
+}
+
+template <typename MatType, int Rows, int Cols, typename DType>
 Matrix<Rows, Cols, DType> operator/(const MatrixBase<MatType, Rows, Cols, DType> &mat, const DType k)
 {
     Matrix<Rows, Cols, DType> ret = mat;
     ret /= k;
+    return ret;
+}
+
+template <typename MatType, int Rows, int Cols, typename DType>
+Matrix<Rows, Cols, DType> operator/(const DType k, const MatrixBase<MatType, Rows, Cols, DType> &mat)
+{
+    Matrix<Rows, Cols, DType> ret;
+    for (int i = 0; i < Rows; ++i)
+    {
+        for (int j = 0; j < Cols; ++j)
+        {
+            ret(i, j) = k / mat(i, j);
+        }
+    }
     return ret;
 }
 

--- a/test/test_arithmetic.cpp
+++ b/test/test_arithmetic.cpp
@@ -125,6 +125,10 @@ TEST(Arithmetic, ElementwiseOperations)
     auto E = A * 1.2f;
     auto F = A / 6.7f;
     auto G = -A;
+    const auto H = 2.5f + A;
+    const auto I = 3.7f - A;
+    const auto J = 1.2f * A;
+    const auto K = 6.7f / A;
 
     for (int i = 0; i < 2; ++i)
     {
@@ -135,6 +139,10 @@ TEST(Arithmetic, ElementwiseOperations)
             EXPECT_FLOAT_EQ(E(i, j), A(i, j) * 1.2);
             EXPECT_FLOAT_EQ(F(i, j), A(i, j) / 6.7);
             EXPECT_FLOAT_EQ(G(i, j), -A(i, j));
+            EXPECT_FLOAT_EQ(H(i, j), 2.5 + A(i, j));
+            EXPECT_FLOAT_EQ(I(i, j), 3.7 - A(i, j));
+            EXPECT_FLOAT_EQ(J(i, j), 1.2 * A(i, j));
+            EXPECT_FLOAT_EQ(K(i, j), 6.7 / A(i, j));
         }
     }
 


### PR DESCRIPTION
If you want this feature, this PR adds operators for elementwise operations with scalar first arguments. This means if you have a matrix A then this pull request adds the ability to write `3 + A`, `3 - A`, `3 * A`, and `3 / A`.  I used this project recently and found this quite useful. I also added the appropriate tests for the feature