### PR TITLE
Cross product operation

### DIFF
--- a/impl/NotSoBasicLinearAlgebra.h
+++ b/impl/NotSoBasicLinearAlgebra.h
@@ -10,6 +10,37 @@ inline void bla_swap(T &a, T &b)
     b = tmp;
 }
 
+template <int Axis = -1, typename ParentTypeA, typename ParentTypeB, int Rows, int Cols>
+Matrix<Rows, Cols, typename ParentTypeA::DType> CrossProduct(
+    const MatrixBase<ParentTypeA, Rows, Cols, typename ParentTypeA::DType> &matA,
+    const MatrixBase<ParentTypeB, Rows, Cols, typename ParentTypeA::DType> &matB)
+{
+    static_assert(Rows == 3 || Cols == 3, "At least one axis has be to dimension three for cross-product");
+    static_assert((Rows != 3 || Cols != 3) || (Axis == 1 || Axis == 0),
+        "For 3-by-3 matrix, the axis (zero or one) for the cross-product operations needs to be specified.");
+    static_assert((Rows == 3 && Cols == 3) || (Axis == -1),
+        "Cross-product operations can only be perfomed along with dimension three.");
+    constexpr int axis = (Rows == 3 && Cols == 3) ? Axis : Cols == 3;
+
+    Matrix<Rows, Cols, typename ParentTypeA::DType> ret;
+    if (axis == 0) {
+        for (int i = 0; i < Cols; ++i)
+        {
+            ret(0,i) = matA(1,i) * matB(2,i) - matB(1,i) * matA(2,i);
+            ret(1,i) = matA(2,i) * matB(0,i) - matB(2,i) * matA(0,i);
+            ret(2,i) = matA(0,i) * matB(1,i) - matB(0,i) * matA(1,i);
+        }
+    } else {
+        for (int i = 0; i < Rows; ++i)
+        {
+            ret(i,0) = matA(i,1) * matB(i,2) - matB(i,1) * matA(i,2);
+            ret(i,1) = matA(i,2) * matB(i,0) - matB(i,2) * matA(i,0);
+            ret(i,2) = matA(i,0) * matB(i,1) - matB(i,0) * matA(i,1);
+        }
+    }
+    return ret;
+}
+
 template <typename ParentType>
 struct LUDecomposition
 {

--- a/impl/NotSoBasicLinearAlgebra.h
+++ b/impl/NotSoBasicLinearAlgebra.h
@@ -10,33 +10,17 @@ inline void bla_swap(T &a, T &b)
     b = tmp;
 }
 
-template <int Axis = -1, typename ParentTypeA, typename ParentTypeB, int Rows, int Cols>
-Matrix<Rows, Cols, typename ParentTypeA::DType> CrossProduct(
-    const MatrixBase<ParentTypeA, Rows, Cols, typename ParentTypeA::DType> &matA,
-    const MatrixBase<ParentTypeB, Rows, Cols, typename ParentTypeA::DType> &matB)
+template <typename ParentTypeA, typename ParentTypeB, int Cols>
+Matrix<3, Cols, typename ParentTypeA::DType> CrossProduct(
+    const MatrixBase<ParentTypeA, 3, Cols, typename ParentTypeA::DType> &matA,
+    const MatrixBase<ParentTypeB, 3, Cols, typename ParentTypeA::DType> &matB)
 {
-    static_assert(Rows == 3 || Cols == 3, "At least one axis has be to dimension three for cross-product");
-    static_assert((Rows != 3 || Cols != 3) || (Axis == 1 || Axis == 0),
-        "For 3-by-3 matrix, the axis (zero or one) for the cross-product operations needs to be specified.");
-    static_assert((Rows == 3 && Cols == 3) || (Axis == -1),
-        "Cross-product operations can only be perfomed along with dimension three.");
-    constexpr int axis = (Rows == 3 && Cols == 3) ? Axis : Cols == 3;
-
-    Matrix<Rows, Cols, typename ParentTypeA::DType> ret;
-    if (axis == 0) {
-        for (int i = 0; i < Cols; ++i)
-        {
-            ret(0,i) = matA(1,i) * matB(2,i) - matB(1,i) * matA(2,i);
-            ret(1,i) = matA(2,i) * matB(0,i) - matB(2,i) * matA(0,i);
-            ret(2,i) = matA(0,i) * matB(1,i) - matB(0,i) * matA(1,i);
-        }
-    } else {
-        for (int i = 0; i < Rows; ++i)
-        {
-            ret(i,0) = matA(i,1) * matB(i,2) - matB(i,1) * matA(i,2);
-            ret(i,1) = matA(i,2) * matB(i,0) - matB(i,2) * matA(i,0);
-            ret(i,2) = matA(i,0) * matB(i,1) - matB(i,0) * matA(i,1);
-        }
+    Matrix<3, Cols, typename ParentTypeA::DType> ret;
+    for (int i = 0; i < Cols; ++i)
+    {
+        ret(0,i) = matA(1,i) * matB(2,i) - matB(1,i) * matA(2,i);
+        ret(1,i) = matA(2,i) * matB(0,i) - matB(2,i) * matA(0,i);
+        ret(2,i) = matA(0,i) * matB(1,i) - matB(0,i) * matA(1,i);
     }
     return ret;
 }

--- a/test/test_linear_algebra.cpp
+++ b/test/test_linear_algebra.cpp
@@ -4,6 +4,51 @@
 
 using namespace BLA;
 
+TEST(LinearAlgebra, CrossProduct)
+{
+    // Axis 0
+    const Matrix<3> A = {1, 2,  3};
+    const Matrix<3> B = {5, 7, 11};
+    const Matrix<3> AB_expected = {1, 4, -3};
+    const auto AB_result = CrossProduct(A, B);
+
+    for (int i = 0; i < AB_result.Rows; i++)
+    {
+        for (int j = 0; j < AB_result.Cols; j++)
+        {
+            EXPECT_FLOAT_EQ(AB_result(i, j), AB_expected(i, j));
+        }
+    }
+    // Axis 1
+    const Matrix<2, 3> C = {1,  2,  3, 5,  7, 11};
+    const Matrix<2, 3> D = {13, 17, 19, 23, 29, 31};
+    const Matrix<2, 3> CD_expected = {-13, 20, -9, -102, 98, -16};
+    const auto CD_result = CrossProduct(C, D);
+
+    for (int i = 0; i < CD_result.Rows; i++)
+    {
+        for (int j = 0; j < CD_result.Cols; j++)
+        {
+            EXPECT_FLOAT_EQ(CD_result(i, j), CD_expected(i, j));
+        }
+    }
+    // 3x3 axis selection
+    const Matrix<3, 3> E = { 1,  2,  3,  5,  7, 11, 13, 17, 19};
+    const Matrix<3, 3> F = {23, 29, 31, 37, 41, 43, 47, 53, 59};
+    const Matrix<3, 3> EF_expected = {-25, 38, -17, -150, 192, -54, -4, 126, -110};
+    const auto EF_result_ax0 = CrossProduct<0>(~E, ~F);
+    const auto EF_result_ax1 = CrossProduct<1>(E, F);
+
+    for (int i = 0; i < EF_expected.Rows; i++)
+    {
+        for (int j = 0; j < EF_expected.Cols; j++)
+        {
+            EXPECT_FLOAT_EQ(EF_result_ax0(i, j), EF_expected(j, i));
+            EXPECT_FLOAT_EQ(EF_result_ax1(i, j), EF_expected(i, j));
+        }
+    }
+}
+
 TEST(LinearAlgebra, LUDecomposition)
 {
     Matrix<7, 7> A = {16, 78, 50, 84, 70, 63, 2, 32, 33, 61, 40, 17, 96, 98, 50, 80, 78, 27, 86, 49, 57, 10, 42, 96, 44,

--- a/test/test_linear_algebra.cpp
+++ b/test/test_linear_algebra.cpp
@@ -19,32 +19,18 @@ TEST(LinearAlgebra, CrossProduct)
             EXPECT_FLOAT_EQ(AB_result(i, j), AB_expected(i, j));
         }
     }
-    // Axis 1
-    const Matrix<2, 3> C = {1,  2,  3, 5,  7, 11};
-    const Matrix<2, 3> D = {13, 17, 19, 23, 29, 31};
-    const Matrix<2, 3> CD_expected = {-13, 20, -9, -102, 98, -16};
-    const auto CD_result = CrossProduct(C, D);
-
-    for (int i = 0; i < CD_result.Rows; i++)
-    {
-        for (int j = 0; j < CD_result.Cols; j++)
-        {
-            EXPECT_FLOAT_EQ(CD_result(i, j), CD_expected(i, j));
-        }
-    }
-    // 3x3 axis selection
+    // The cross product will always be computed on the second axis.
+    // This can be changed by transposing the matricies.
     const Matrix<3, 3> E = { 1,  2,  3,  5,  7, 11, 13, 17, 19};
     const Matrix<3, 3> F = {23, 29, 31, 37, 41, 43, 47, 53, 59};
     const Matrix<3, 3> EF_expected = {-25, 38, -17, -150, 192, -54, -4, 126, -110};
-    const auto EF_result_ax0 = CrossProduct<0>(~E, ~F);
-    const auto EF_result_ax1 = CrossProduct<1>(E, F);
+    const auto EF_result = CrossProduct(~E, ~F);
 
     for (int i = 0; i < EF_expected.Rows; i++)
     {
         for (int j = 0; j < EF_expected.Cols; j++)
         {
-            EXPECT_FLOAT_EQ(EF_result_ax0(i, j), EF_expected(j, i));
-            EXPECT_FLOAT_EQ(EF_result_ax1(i, j), EF_expected(i, j));
+            EXPECT_FLOAT_EQ(EF_result(i, j), EF_expected(j, i));
         }
     }
 }


### PR DESCRIPTION
This PR adds a three-dimensional [cross product](https://en.wikipedia.org/wiki/Cross_product) operation (with appropriate tests). This means you can do cross-products with all matrices that have dimension 3 along either the first or the second axis. If the matrix is 3-by-4, then the axis for the cross-product operation can be chosen at compile-time.